### PR TITLE
luminance_study not a library, fixing #14

### DIFF
--- a/libraries/exclusions/luminance_study
+++ b/libraries/exclusions/luminance_study
@@ -1,0 +1,1 @@
+{"obsolete" : "Not a python package"}


### PR DESCRIPTION
Also running the workflow, realised luminance_study which is within scikit-surgery universe, is actually not a python package and should be excluded 